### PR TITLE
Fixed issues with duplicate vendor and product IDs 

### DIFF
--- a/KD100.c
+++ b/KD100.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include<unistd.h>
+#include <unistd.h>
 #include <pwd.h>
 
 int keycodes[] = {1, 2, 4, 8, 16, 32, 64, 128, 129, 130, 132, 136, 144, 160, 192, 256, 257, 258, 260, 641, 642};

--- a/KD100.c
+++ b/KD100.c
@@ -382,7 +382,7 @@ int main(int args, char *in[])
 			printf("\t-a\t\tAssume the first device that matches %04x:%04x is the Keydial\n", vid, pid);
 			printf("\t-c [path]\tSpecifies a config file to use\n");
 			printf("\t-d [-d]\t\tEnable debug outputs (use twice to view data sent by the device)\n");
-			printf("\t-h\t\tDisplays this message\n");
+			printf("\t-h\t\tDisplays this message\n\n");
 			return 0;
 		}
 		if (strcmp(in[arg],"-d") == 0){

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Usage
 ```
 sudo ./KD100 [options]
 ```
-**-a**  Assume that the first device that matches the vid and pid is the keydial
+**-a**  Assume that the first device that matches the vid and pid is the keydial (skips prompt to select a device)
 
 **-c**  Specify a config file to use after the flag (./default.cfg or ~/.config/KD100/default.cfg is used normally)
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,19 @@ make
 Usage
 -----
 ```
-sudo ./KD100 -c config_file -d
+sudo ./KD100 [options]
 ```
-**-c**  Specify a config file (default.cfg is used normally)
+**-a**  Assume that the first device that matches the vid and pid is the keydial
+
+**-c**  Specify a config file to use after the flag (./default.cfg or ~/.config/KD100/default.cfg is used normally)
 
 **-d**  Enable debug output (can be used twice to output the full packet of data recieved from the device)
 
+**-h**  Displays a help message
+
 Configuring
 ----------
-Edit or copy **default.cfg** to add your own keys/commands 
+Edit or copy **default.cfg** to add your own keys/commands and use the '-c' flag to specify the location of the config file
 > **_NOTE:_**  New config files must have the same format and line count as the default file
 
 Caveats
@@ -43,7 +47,7 @@ Caveats
 ```
 SUBSYSTEM=="usb",ATTRS{idVendor}=="256c",ATTRS{idProduct}=="006d",MODE="0666",GROUP="plugdev"
 ```
-- Sometimes the driver won't find the device and might require you to unplug it and plug it back in to fix it
+- If the driver is ran as a user and the '-a' flag is not used, you will need to select the device to use during startup
 - Technically speaking, this can support other devices, especially if they send the same type of byte information, otherwise the code should be easy enough to edit and add support for other usb devices. If you want to see the information sent by different devices, change the vid and pid in the program and run it with two debug flags
 
 Tested Distros


### PR DESCRIPTION
The driver now grabs a list of all USB devices that match the vendor ID and product ID of the Mini Keydial and does one of the following depending upon how the driver is ran:
- As root - The driver looks for the device without a description and selects that instead. For some reason, Huion decided that the Keydial didn't need a description while other products got one
- As a user - The driver lists all devices that match the vendor ID and product ID along with the bus and device number and displays attached devices using the "lsusb" command. This is only here because getting device descriptions require root permission
- With the '-a' flag - The driver acts as it did before and grabs the first matching device

New flags:
- '-a' - Assumes the first matching device is the Mini Keydial
- '-h' - Displays a help message

Other fixes:
- The driver should find the device all the time now
- Added a check to make sure the driver has permission to access the USB before running