### PR TITLE
v1.4

### DIFF
--- a/KD100.c
+++ b/KD100.c
@@ -67,12 +67,19 @@ void GetDevice(int debug, int accept, int dry){
 	}else{
 		f = fopen(file, "r");
 		if (f == NULL){
-			strcpy(file, getpwuid(getuid())->pw_dir);
-			strcat(file, "/.config/KD100/default.cfg");
-			f = fopen(file, "r");
+			char* home = getpwuid(getuid())->pw_dir;
+			file = "/.config/KD100/default.cfg";
+			char temp[strlen(file)+strlen(home)+1];
+			for (int i = 0; i < strlen(home); i++)
+				temp[i] = home[i];
+			for (int i = 0; i < strlen(file); i++)
+				temp[i+strlen(home)] = file[i];
+			temp[strlen(temp)] = '\0';
+
+			f = fopen(temp, "r");
 			if (f == NULL){
 				printf("DEFAULT CONFIGS ARE MISSING!\n");
-				printf("Please add default.cfg to %s/.config/KD100/ or specify a file to use with -c\n", getpwuid(getuid())->pw_dir);
+				printf("Please add default.cfg to %s/.config/KD100/ or specify a file to use with -c\n", home);
 				return;
 			}
 		}
@@ -419,7 +426,7 @@ void Handler(char* key, int type){
 		if (mouse == 'a'){
 			for (int i = 0; i < strlen(key); i++)
 				temp[i+strlen(cmd)] = key[i];
-			temp[strlen(cmd) + strlen(key)] = '\0';
+			temp[strlen(cmd)+strlen(key)] = '\0';
 		}else{
 			temp[strlen(cmd)] = ' ';
 			temp[strlen(cmd)+1] = mouse;
@@ -471,12 +478,14 @@ int main(int args, char *in[])
 			accept=1;
 		}
 		if (strcmp(in[arg], "-c") == 0){
-			if (strlen(in[arg+1]) > 0){
-				strcpy(file, in[arg+1]);
+			if (in[arg+1]){
+				file = in[arg+1];
+				printf("%s\n", file);
 				arg++;
-			}else
+			}else{
 				printf("No config file specified. Exiting...\n");
 				return -8;
+			}
 		}
 	}
 

--- a/KD100.c
+++ b/KD100.c
@@ -1,7 +1,7 @@
 /*
 	V1.4
 	https://github.com/mckset/KD100.git
-	KD 100 Linux driver for X11 desktops
+	KD100 Linux driver for X11 desktops
 	Other devices can be supported by modifying the code to read data received by the device
 	At the moment, only the KD100 mini keypad is supported by this code officially
 */
@@ -150,7 +150,7 @@ void GetDevice(int debug, int accept, int dry){
 	while (err == 0 || err == LIBUSB_ERROR_NO_DEVICE){
 		libusb_device **devs; // List of USB devices
 		libusb_device *dev; // Selected USB device
-		struct libusb_config_descriptor *desc; // USB descrition (For claiming interfaces)
+		struct libusb_config_descriptor *desc; // USB description (For claiming interfaces)
 		libusb_device_handle *handle = NULL; // USB handle
 
 		err = libusb_get_device_list(NULL, &devs);
@@ -505,8 +505,8 @@ int main(int args, char *in[])
 		printf("Error: %d\n", err);
 		return err;
 	}
-	// Uncomment to enable libusb debug messages (might not work with older versions of libusb)
-	// libusb_set_option(*ctx, LIBUSB_OPTION_LOG_LEVEL, 1);
+	// Uncomment to enable libusb debug messages
+	// libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, 1);
 	GetDevice(debug, accept, dry);
 	libusb_exit(ctx);
 	return 0;

--- a/README.md
+++ b/README.md
@@ -33,16 +33,18 @@ sudo ./KD100 [options]
 
 **-d**  Enable debug output (can be used twice to output the full packet of data recieved from the device)
 
+**-dry**  Displays data sent from the keydial without send events to the program
+
 **-h**  Displays a help message
 
 Configuring
 ----------
 Edit or copy **default.cfg** to add your own keys/commands and use the '-c' flag to specify the location of the config file
-> **_NOTE:_**  New config files must have the same format and line count as the default file
+> **_NOTE:_**  Config files from v1.31 and below need to be updated. See the example config file for the changes to the wheel function and wheel button
 
 Caveats
 -------
-- This only works on X11 based desktops (because of xdotool)
+- This only works on X11 based desktops (because it relies on xdotool)
 - You do not need to run this with sudo if you set a udev rule for the device. Create/edit a rule file in /etc/udev/rules.d/ and add the following, then save and reboot or reload your udev rules
 ```
 SUBSYSTEM=="usb",ATTRS{idVendor}=="256c",ATTRS{idProduct}=="006d",MODE="0666",GROUP="plugdev"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Huion KD100 Linux Driver
 A simple driver for the Huion KD100 mini Keydial written in C to give the device some usability while waiting for Huion to fix their Linux drivers. Each button can be configured to either act as a key/multiple keys or to execute a program/command
 
+> **_NOTICE:_**  When updating from **v1.31** or below, make sure you updated your config file to follow the new format shown in the default config file
+
 Pre-Installation
 ------------
-Arch Linux:
+Arch Linux/Manjaro:
 ```
 sudo pacman -S libusb-1.0 xdotool
 ```
-Ubuntu/Debian:
+Ubuntu/Debian/Pop OS:
 ```
-sudo apt-get install libusb-1.0 xdotool
+sudo apt-get install libusb-1.0-0-dev xdotool
 ```
 > **_NOTE:_**  Some distros label libusb as "libusb-1.0-0" and others might require the separate "libusb-1.0-dev" package
 
@@ -22,6 +24,8 @@ cd KD100
 make
 ```
 
+> Running make as root will install the driver as a command and create a folder in ~/.config to store config files
+
 Usage
 -----
 ```
@@ -33,23 +37,21 @@ sudo ./KD100 [options]
 
 **-d**  Enable debug output (can be used twice to output the full packet of data recieved from the device)
 
-**-dry**  Displays data sent from the keydial without send events to the program
+**-dry**  Display data sent from the keydial and ignore events
 
 **-h**  Displays a help message
 
 Configuring
 ----------
-Edit or copy **default.cfg** to add your own keys/commands and use the '-c' flag to specify the location of the config file
-> **_NOTE:_**  Config files from v1.31 and below need to be updated. See the example config file for the changes to the wheel function and wheel button
+Edit or copy **default.cfg** to add your own keys/commands and use the '-c' flag to specify the location of the config file. New config files do not need to end in ".cfg".
 
 Caveats
 -------
-- This only works on X11 based desktops (because it relies on xdotool)
+- This only works on X11 based desktops (because it relies on xdotool) but can be patched for wayland desktops by altering the "handler" function
 - You do not need to run this with sudo if you set a udev rule for the device. Create/edit a rule file in /etc/udev/rules.d/ and add the following, then save and reboot or reload your udev rules
 ```
 SUBSYSTEM=="usb",ATTRS{idVendor}=="256c",ATTRS{idProduct}=="006d",MODE="0666",GROUP="plugdev"
 ```
-- If the driver is ran as a user and the '-a' flag is not used, you will need to select the device to use during startup
 - Technically speaking, this can support other devices, especially if they send the same type of byte information, otherwise the code should be easy enough to edit and add support for other usb devices. If you want to see the information sent by different devices, change the vid and pid in the program and run it with two debug flags
 
 Tested Distros
@@ -57,7 +59,7 @@ Tested Distros
 - Arch linux
 - Manjaro
 - Ubuntu
-- Kali Linux
+- Pop OS
 
 Known Issues
 ------------

--- a/default.cfg
+++ b/default.cfg
@@ -1,11 +1,33 @@
 // KD100 config file
-// The driver supports two key functions
+// 
+//	Assumptions:
+//		- (B)utton defines a new button and the following number specifies which button it is. Without the paranthesis, the previous sentence would define a new button
+//		- (B)uttons do not need to be listed in order but their type and function must be listed on separate lines afterwards
+//		- (B)utton definitions can be skipped if you don't want all the buttons to work on the keydial
+//		- (B)utton, type, and function definitions can contain numbers, symbols, or letters before hand but must have a number or function after the ':'
+//		- Ex) @#$!123ttype: 1 - is valid
+//		- type: f02r - will default to type 0
+//		- type and function definitions must be lower case but can be in any order
+//		- The program defaults the type to 0 and the function to null
+//		- The (W)heel works in two parts. The first definition assigns all functions for turning it clockwise while the second definition assigns counter clockwise functions
+//		- The wheel functions must be defined at the end of the config file
+//		- If one wheel side has more functions than the other, it will set the function of the other wheel to NULL and do nothing when turning the wheel that way
+//		- Three wheel functions are provided but there is no limit to the amount you can add
+//		- Both button and wheel definitions do not need '//' before them and the wheel definition doesn't need the text after it to work
+//		- '//' is not required to add comments to the file but anything after a function, type, or button will be included in the program
+//		- All other text is skipped by the program
+//		- Wheel functions cannot run programs or act as mouse input
+// 		
+//	(B)utton Types:
 //	0: Key - The pressed button acts as a key or a combination of keys
 //		ex) a = key 'A' | ctrl+a = control and 'A' at the same time
 //	1: function - The pressed button runs a bash command/script
 //		ex) krita | echo Hello world | gpio www.example.com
-//		NOTE: "swap" changes the wheel buttons function and "mouse1/2/3/4/5" activates mouse buttons (left/middle/right/scroll up/ scroll down)
-//	Each key is numbered from the top left to the bottom right and keeps the wheel and button separate
+//		NOTE: "swap" changes the wheel buttons function 
+//	2:	Mouse buttons - Specify mouse1, 2, 3, 4, or 5 activates mouse buttons (left/middle/right/scroll up/ scroll down)
+//		ex) type: 2 function: mouse1
+//
+//	Each key is numbered from the top left to the bottom right and keeps the wheel and button separate. The wheel button is button 18
 //	|---------------|
 //	| 0 | 1 | 2 | 3 |
 //	|---|---|---|---|
@@ -72,14 +94,14 @@ function: ctrl+s
 // Button 17
 type: 0
 function: Insert
-// Button Wheel Button
+// Dial Button 18
 type: 1
 function: swap
-// Button Wheel Clockwise (MUST BE A KEY COMMAND or NULL to return to the first function)
-function 1: ctrl+KP_Add
-function 2: bracketright
-function 3: NULL
-// Button Wheel Counter-Clockwise (MUST BE A KEY COMMAND)
-function 1: ctrl+minus
-function 2: bracketleft
-function 3: NULL
+// Wheel Clockwise
+function: ctrl+KP_Add
+function: bracketright
+function: NULL
+// Wheel Counter-Clockwise
+function: ctrl+minus
+function: bracketleft
+function: NULL

--- a/default.cfg
+++ b/default.cfg
@@ -16,7 +16,7 @@
 //		- Both button and wheel definitions do not need '//' before them and the wheel definition doesn't need the text after it to work
 //		- '//' is not required to add comments to the file but anything after a function, type, or button will be included in the program
 //		- All other text is skipped by the program
-//		- Wheel functions cannot run programs or act as mouse input
+//		- (W)heel functions cannot run programs or act as mouse input
 // 		
 //	(B)utton Types:
 //	0: Key - The pressed button acts as a key or a combination of keys


### PR DESCRIPTION
- Fixed segmentation fault on some distros when initializing libusb
- Fixed segmentation faults when closing libusb on some distros
- Changed how the driver reads config files:
    1) Keybindings and functions no longer have a character limit
    2) The config file no longer needs to have the same line count as the default file
    3) The dial can now have as many functions as the user specifies
    4) Buttons can now be defined in any order or can be removed from the file without causing any issues
- Added the "dry" run command to display received data without triggering events
- Cleaned up some of the messy code and removed the character limit when specifying custom config files
- Added a level 1 debug output to list all the functions that the program got from the config file
- Commented out the libusb _set_option function for debug use only
- Fixed segmentation fault when calling libusb_set_option
- Fixed minor spelling issues
- Tested on Pop OS